### PR TITLE
exec: spawn new shell on no arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,22 @@ $ env | grep -i cloudflare
 # => no results
 
 $ cf-vault exec work -- env | grep -i cloudflare
+CLOUDFLARE_VAULT_SESSION=work
 CLOUDFLARE_EMAIL=jacob@example.com
 CLOUDFLARE_API_KEY=s3cr3t
+```
+
+If you don't provide a command, you will be dropped into a new shell with the
+credentials populated.
+
+```shell
+$ cf-vault exec work
+$ env | grep -i cloudflare
+CLOUDFLARE_VAULT_SESSION=work
+CLOUDFLARE_EMAIL=jacob@example.com
+CLOUDFLARE_API_KEY=s3cr3t
+
+$ exit
+$ env | grep -i cloudflare
+# => no results
 ```

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -19,6 +19,11 @@ var addCmd = &cobra.Command{
 	Use:   "add [profile]",
 	Short: "Add a new profile to your configuration and keychain",
 	Long:  "",
+	Example: `
+  Add a new profile (you will be prompted for credentials)
+
+    $ cf-vault add example-profile
+`,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
 			return errors.New("requires a profile argument")

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -65,11 +65,7 @@ var addCmd = &cobra.Command{
 		cfg.Section(fmt.Sprintf("profile %s", profileName)).NewKey("auth_type", authType)
 		cfg.SaveTo(home + defaultFullConfigPath)
 
-		ring, _ := keyring.Open(keyring.Config{
-			FileDir:      "~/.cf-vault/keys/",
-			ServiceName:  projectName,
-			KeychainName: projectName,
-		})
+		ring, _ := keyring.Open(keyringDefaults)
 
 		_ = ring.Set(keyring.Item{
 			Key:  fmt.Sprintf("%s-%s", profileName, authType),

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -53,9 +53,6 @@ var execCmd = &cobra.Command{
 			log.Fatal(fmt.Sprintf("no profile matching %q found in the configuration file at %s", profileName, defaultFullConfigPath))
 		}
 
-		ring, _ := keyring.Open(keyringDefaults)
-
-		keychain, _ := ring.Get(fmt.Sprintf("%s-%s", profileName, profileSection.Key("auth_type").String()))
 
 		command := strings.Split(args[1], " ")
 		executable := command[0]
@@ -64,6 +61,8 @@ var execCmd = &cobra.Command{
 			log.Fatalf("couldn't find the executable '%s': %w", executable, err)
 		}
 
+		ring, _ := keyring.Open(keyringDefaults)
+		keychain, _ := ring.Get(fmt.Sprintf("%s-%s", profileName, profileSection.Key("auth_type").String()))
 
 		runningCommand := exec.Command(executable, args...)
 		runningCommand.Env = append(os.Environ(),

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -20,6 +20,22 @@ var execCmd = &cobra.Command{
 	Use:   "exec [profile]",
 	Short: "Execute a command with Cloudflare credentials populated",
 	Long:  "",
+	Example: `
+  Execute a single command with credentials populated
+
+    $ cf-vault exec example-profile -- env | grep -i cloudflare
+    CLOUDFLARE_VAULT_SESSION=example-profile
+    CLOUDFLARE_EMAIL=jacob@example.com
+    CLOUDFLARE_API_KEY=s3cr3t
+
+  Spawn a new shell with credentials populated
+
+    $ cf-vault exec example-profile --
+    $ env | grep -i cloudflare
+    CLOUDFLARE_VAULT_SESSION=example-profile
+    CLOUDFLARE_EMAIL=jacob@example.com
+    CLOUDFLARE_API_KEY=s3cr3t
+`,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
 			return errors.New("requires a profile argument")

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -48,11 +48,7 @@ var execCmd = &cobra.Command{
 			log.Fatal(fmt.Sprintf("no profile matching %q found in the configuration file at %s", profileName, defaultFullConfigPath))
 		}
 
-		ring, _ := keyring.Open(keyring.Config{
-			FileDir:      "~/.cf-vault/keys/",
-			ServiceName:  projectName,
-			KeychainName: projectName,
-		})
+		ring, _ := keyring.Open(keyringDefaults)
 
 		keychain, _ := ring.Get(fmt.Sprintf("%s-%s", profileName, profileSection.Key("auth_type").String()))
 

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -32,6 +32,11 @@ var execCmd = &cobra.Command{
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		profileName := args[0]
+		// Remove the extra executable name at the beginning of the slice.
+		copy(args[0:], args[0+1:])
+		args[len(args)-1] = ""
+		args = args[:len(args)-1]
+
 		log.Debug("using profile: ", profileName)
 
 		home, err := homedir.Dir()
@@ -59,12 +64,6 @@ var execCmd = &cobra.Command{
 			log.Fatalf("couldn't find the executable '%s': %w", executable, err)
 		}
 
-		log.Printf("found executable %s", argv0)
-
-		// Remove the extra executable name at the beginning of the slice.
-		copy(args[0:], args[0+1:])
-		args[len(args)-1] = ""
-		args = args[:len(args)-1]
 
 		runningCommand := exec.Command(executable, args...)
 		runningCommand.Env = append(os.Environ(),

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,16 +1,31 @@
 package cmd
 
 import (
+	"fmt"
+
+	"github.com/99designs/keyring"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
 var (
-	verbose                bool
-	projectName            = "cf-vault"
-	defaultConfigDirectory = "/." + projectName
-	defaultFullConfigPath  = defaultConfigDirectory + "/config"
+	verbose                  bool
+	projectName              = "cf-vault"
+	projectNameWithoutHyphen = "cfvault"
+	defaultConfigDirectory   = "/." + projectName
+	defaultFullConfigPath    = defaultConfigDirectory + "/config"
 )
+
+var keyringDefaults = keyring.Config{
+	FileDir:                  fmt.Sprintf("~/.%s/keys/", projectName),
+	ServiceName:              projectName,
+	KeychainName:             projectName,
+	LibSecretCollectionName:  projectNameWithoutHyphen,
+	KWalletAppID:             projectName,
+	KWalletFolder:            projectName,
+	KeychainTrustApplication: true,
+	WinCredPrefix:            projectName,
+}
 
 var rootCmd = &cobra.Command{
 	Use:  projectName,


### PR DESCRIPTION
When no arguments are provided, spawn a fresh shell with the current
environment and the credentials populated.

Closes #2