### PR TITLE
exec: Check for config file before trying to use it

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -60,7 +60,12 @@ var execCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal("unable to find home directory: ", err)
 		}
+
 		cfg, err := ini.Load(home + defaultFullConfigPath)
+		if err != nil {
+			log.Fatal("unable to use configuration file: ", err)
+		}
+
 		profileSection, err := cfg.GetSection("profile " + profileName)
 		if err != nil {
 			log.Fatal("unable to find profile: ", err)


### PR DESCRIPTION
Updates the `exec` flow to check the `config` file exists before
attempting to pull data from it.

Fixes #12