### PR TITLE
Handle multiple policies

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -24,11 +24,22 @@ type tomlConfig struct {
 }
 
 type profile struct {
-	Email              string                 `toml:"email"`
-	AuthType           string                 `toml:"auth_type"`
-	SessionDuration    string                 `toml:"session_duration,omitempty"`
-	Resources          map[string]interface{} `toml:"resources,omitempty"`
-	PermissionGroupIDs []string               `toml:"permission_group_ids,omitempty"`
+	Email           string   `toml:"email"`
+	AuthType        string   `toml:"auth_type"`
+	SessionDuration string   `toml:"session_duration,omitempty"`
+	Policies        []policy `toml:"policies,omitempty"`
+}
+
+type policy struct {
+	Effect           string                 `toml:"effect"`
+	ID               string                 `toml:"id,omitempty"`
+	PermissionGroups []permissionGroup      `toml:"permission_groups"`
+	Resources        map[string]interface{} `toml:"resources"`
+}
+
+type permissionGroup struct {
+	ID   string `toml:"id"`
+	Name string `toml:"name,omitempty"`
 }
 
 var addCmd = &cobra.Command{

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -1,0 +1,24 @@
+package cmd
+
+import "strings"
+
+// environ is a slice of strings representing the environment, in the form
+// "key=value".
+type environ []string
+
+// Unset an environment variable by key
+func (e *environ) Unset(key string) {
+	for i := range *e {
+		if strings.HasPrefix((*e)[i], key+"=") {
+			(*e)[i] = (*e)[len(*e)-1]
+			*e = (*e)[:len(*e)-1]
+			break
+		}
+	}
+}
+
+// Set adds an environment variable, replacing any existing ones of the same key
+func (e *environ) Set(key, val string) {
+	e.Unset(key)
+	*e = append(*e, key+"="+val)
+}


### PR DESCRIPTION
In #20, I was only testing single policies however it is more likely
you'll encounter multiple policies for tokens as there are varying
resource levels. This takes into account all the policy options and
fixes overwriting environment variables instead of just appending it.