### PR TITLE
cmd/list: Add ability to list all profiles

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,0 +1,78 @@
+package cmd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/mitchellh/go-homedir"
+	"github.com/olekukonko/tablewriter"
+	"github.com/pelletier/go-toml"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all available profiles",
+	Long:  "",
+	PreRun: func(cmd *cobra.Command, args []string) {
+		if verbose {
+			log.SetLevel(log.DebugLevel)
+		}
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		home, err := homedir.Dir()
+		if err != nil {
+			log.Fatal("unable to find home directory: ", err)
+		}
+
+		configData, err := ioutil.ReadFile(home + defaultFullConfigPath)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		config := tomlConfig{}
+		err = toml.Unmarshal(configData, &config)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		if len(config.Profiles) == 0 {
+			fmt.Printf("no profiles found at %s\n", home+defaultFullConfigPath)
+			os.Exit(0)
+		}
+
+		tableData := [][]string{}
+		for profileName, profile := range config.Profiles {
+			// Only display the email if we're using API tokens otherwise the value is
+			// not used and pretty superfluous.
+			var emailString string
+			if profile.AuthType == "api_key" {
+				emailString = profile.Email
+			}
+
+			tableData = append(tableData, []string{
+				profileName,
+				profile.AuthType,
+				emailString,
+			})
+		}
+
+		table := tablewriter.NewWriter(os.Stdout)
+		table.SetHeader([]string{"Profile name", "Authentication type", "Email"})
+		table.SetAutoWrapText(false)
+		table.SetAutoFormatHeaders(true)
+		table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+		table.SetAlignment(tablewriter.ALIGN_LEFT)
+		table.SetCenterSeparator("")
+		table.SetColumnSeparator("")
+		table.SetRowSeparator("")
+		table.SetHeaderLine(false)
+		table.SetBorder(false)
+		table.SetTablePadding("\t")
+		table.SetNoWhiteSpace(true)
+		table.AppendBulk(tableData)
+		table.Render()
+	},
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -50,6 +50,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "increase the verbosity of the output")
 
 	rootCmd.AddCommand(addCmd)
+	rootCmd.AddCommand(listCmd)
 	rootCmd.AddCommand(execCmd)
 	rootCmd.AddCommand(versionCmd)
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,9 @@ go 1.15
 require (
 	github.com/99designs/keyring v1.1.6
 	github.com/cloudflare/cloudflare-go v0.13.5
+	github.com/davecgh/go-spew v1.1.1
 	github.com/mitchellh/go-homedir v1.1.0
+	github.com/olekukonko/tablewriter v0.0.4
 	github.com/pelletier/go-toml v1.8.2-0.20201011232708-5b4e7e5dcc56
 	github.com/sirupsen/logrus v1.7.0
 	github.com/spf13/cobra v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -131,6 +131,7 @@ github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
+github.com/mattn/go-runewidth v0.0.7 h1:Ei8KR0497xHyKJPAv59M1dkC+rOZCMBJ+t3fZ+twI54=
 github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
@@ -150,6 +151,7 @@ github.com/mtibben/percent v0.2.1 h1:5gssi8Nqo8QU/r2pynCm+hBQHpkB/uNK7BJCFogWdzs
 github.com/mtibben/percent v0.2.1/go.mod h1:KG9uO+SZkUp+VkRHsCdYQV3XSZrrSpR3O9ibNBTZrns=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
+github.com/olekukonko/tablewriter v0.0.4 h1:vHD/YYe1Wolo78koG299f7V/VAS08c6IpCLn+Ejf/w8=
 github.com/olekukonko/tablewriter v0.0.4/go.mod h1:zq6QwlOf5SlnkVbMSr5EoBv3636FWnp+qbPhuoO21uA=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=


### PR DESCRIPTION
Creates a `list` command which will allow you to list all configured
profiles. At the moment, the output is only profile name, auth mechanism
and the email associated (for API keys). This can be extended in the
future as more information is needed.

Example output

```
PROFILE NAME    	AUTHENTICATION TYPE	EMAIL
test-api-key    	api_key            	jacob@example.com
test-api-token  	api_token
```

Closes #8