### PR TITLE
Fix password prompt file keyring issue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/pelletier/go-toml v1.9.5
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.5.0
-	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d
+	golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616
 	golang.org/x/tools/gopls v0.9.5
 )

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,8 @@ golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d h1:sK3txAijHtOK88l68nt020reeT1ZdKLIYetKl95FzVY=
-golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90 h1:Y/gsMcFOcR+6S6f3YeMKl5g+dZMEWqcz5Czj/GWYbkM=
+golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e h1:+WEEuIdZHnUeJJmEUjyYC2gfUMj69yZXw17EnHg/otA=
 golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e/go.mod h1:Kr81I6Kryrl9sr8s2FK3vxD90NdsKWRuOIl2O4CvYbA=
 golang.org/x/exp/typeparams v0.0.0-20220218215828-6cf2b201936e/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=


### PR DESCRIPTION
Hello!
This is a fix of error:
```
$ cf-vault add my-profile
Email address: my@email.com
Authentication value (API key or API token): 
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x745479]

goroutine 1 [running]:
github.com/99designs/keyring.(*fileKeyring).unlock(0xc0001085a0, 0xc000078730, 0xc000116000)
	/vagrant/app/n/pkg/mod/github.com/99designs/keyring@v1.1.6/file.go:71 +0xd9
github.com/99designs/keyring.(*fileKeyring).Set(0xc0001085a0, 0xc000030900, 0x15, 0xc0000263c0, 0x28, 0x30, 0x0, 0x0, 0x0, 0x0, ...)
	/vagrant/app/n/pkg/mod/github.com/99designs/keyring@v1.1.6/file.go:140 +0xcb
github.com/jacobbednarz/cf-vault/cmd.glob..func3(0xba5e40, 0xc00005f1d0, 0x1, 0x1)
	/vagrant/cf-vault/cmd/add.go:174 +0xf55
github.com/spf13/cobra.(*Command).execute(0xba5e40, 0xc00005f1b0, 0x1, 0x1, 0xba5e40, 0xc00005f1b0)
	/vagrant/app/n/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:860 +0x2c2
github.com/spf13/cobra.(*Command).ExecuteC(0xba6340, 0x0, 0xffffffff, 0xc0000360b8)
	/vagrant/app/n/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:974 +0x375
github.com/spf13/cobra.(*Command).Execute(...)
	/vagrant/app/n/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:902
github.com/jacobbednarz/cf-vault/cmd.Execute(...)
	/vagrant/cf-vault/cmd/root.go:78
main.main()
	/vagrant/cf-vault/main.go:8 +0x2e
```

It appeared when using `cf-vault` in Ubuntu 20.04 terminal (inside vagrant).
Connected with missing password prompt function in `github.com/99designs/keyring` library.

Better to test this code on Mac OS X and Windows (only checked on Linux machine)
Fix was copied from `https://github.com/99designs/aws-vault` code