### PR TITLE
release: use osxcross for better cross compiling support

### DIFF
--- a/.github/workflows/bump-cask.yaml
+++ b/.github/workflows/bump-cask.yaml
@@ -21,14 +21,11 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: "1.20"
-      - uses: mislav/bump-homebrew-formula-action@v2
+      - name: Bump Homebrew tap
+        uses: macauley/action-homebrew-bump-cask@v1
         with:
-          formula-name: cf-vault
-          formula-path: Casks/cf-vault.rb
-          homebrew-tap: jacobbednarz/homebrew-tap
-          base-branch: master
-          download-url: https://github.com/jacobbednarz/cf-vault/releases/download/${{ github.event.inputs.tag-name }}/cf-vault_${{ github.event.inputs.tag-name }}_darwin_amd64.zip
-          commit-message: Bump {{formulaName}} to {{version}}
-          tag-name: ${{ github.event.inputs.tag-name }}
-        env:
-          COMMITTER_TOKEN: ${{ secrets.HOMEBREW_UPDATER_PAT }}
+          token: ${{ secrets.HOMEBREW_UPDATER_PAT }}
+          tap: jacobbednarz/homebrew-tap
+          cask: cf-vault
+          livecheck: true
+          dryrun: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,10 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: "1.20"
+      - name: OSXCross for CGO Support
+        run: |
+          mkdir ../../osxcross
+          git clone https://github.com/plentico/osxcross-target.git ../../osxcross/target
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,16 +28,14 @@ jobs:
         uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: mislav/bump-homebrew-formula-action@v2
+      - name: Bump Homebrew tap
+        uses: macauley/action-homebrew-bump-cask@v1
         with:
-          formula-name: cf-vault
-          formula-path: Casks/cf-vault.rb
-          homebrew-tap: jacobbednarz/homebrew-tap
-          base-branch: master
-          download-url: https://github.com/jacobbednarz/cf-vault/releases/download/${{ steps.extract-version.outputs.tag-name }}/cf-vault_${{ steps.extract-version.outputs.tag-name }}_darwin_amd64.zip
-          commit-message: Bump {{formulaName}} to {{version}}
-        env:
-          COMMITTER_TOKEN: ${{ secrets.HOMEBREW_UPDATER_PAT }}
+          token: ${{ secrets.HOMEBREW_UPDATER_PAT }}
+          tap: jacobbednarz/homebrew-tap
+          cask: cf-vault
+          livecheck: true
+          dryrun: false

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,20 +1,20 @@
 builds:
-  - id: linux-build
-    flags:
-      - -trimpath
-    asmflags:
-      - all=-trimpath=$GOPATH
-    gcflags:
-      - all=-trimpath=$GOPATH
-    ldflags:
-      - -s -w -X github.com/jacobbednarz/cf-vault/cmd.Rev={{ .Version }}
-    env:
-      - CGO_ENABLED=1
-    goos:
-      - linux
-    ignore:
-      - goos: linux
-        goarch: "386"
+  # - id: linux-build
+  #   flags:
+  #     - -trimpath
+  #   asmflags:
+  #     - all=-trimpath=$GOPATH
+  #   gcflags:
+  #     - all=-trimpath=$GOPATH
+  #   ldflags:
+  #     - -s -w -X github.com/jacobbednarz/cf-vault/cmd.Rev={{ .Version }}
+  #   env:
+  #     - CGO_ENABLED=1
+  #   goos:
+  #     - linux
+  #   ignore:
+  #     - goos: linux
+  #       goarch: "386"
   - id: darwin-build
     flags:
       - -trimpath

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,5 @@
 builds:
-  - env:
-      - CGO_ENABLED=0
-    mod_timestamp: '{{ .CommitTimestamp }}'
+  - id: linux-build
     flags:
       - -trimpath
     asmflags:
@@ -10,16 +8,39 @@ builds:
       - all=-trimpath=$GOPATH
     ldflags:
       - -s -w -X github.com/jacobbednarz/cf-vault/cmd.Rev={{ .Version }}
+    env:
+      - CGO_ENABLED=1
+    goos:
+      - linux
+    ignore:
+      - goos: linux
+        goarch: "386"
+  - id: darwin-build
+    flags:
+      - -trimpath
+    asmflags:
+      - all=-trimpath=$GOPATH
+    gcflags:
+      - all=-trimpath=$GOPATH
+    ldflags:
+      - -s -w -X github.com/jacobbednarz/cf-vault/cmd.Rev={{ .Version }}
+    env:
+      - CGO_ENABLED=1
+      - CC=/home/runner/work/osxcross/target/bin/o64-clang
+      - CXX=/home/runner/work/osxcross/target/bin/o64-clang++
     goos:
       - darwin
-      - freebsd
-      - linux
-      - windows
+    ignore:
+      - goos: darwin
+        goarch: "386"
+
 archives:
   - format: zip
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+
 checksum:
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
   algorithm: sha256
+
 changelog:
   skip: true


### PR DESCRIPTION
Updates the release process to perform better cross compiling support and ultimately, set `CGO_ENABLED=1` in the releases.

This does drop Windows and FreeBSD support however, I don't have a great testing story for them at the moment so we can revisit when/if the request arises.