### PR TITLE
Keyring debugging and error handling, support `darwin/arm64`

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -62,6 +62,7 @@ var addCmd = &cobra.Command{
 	PreRun: func(cmd *cobra.Command, args []string) {
 		if verbose {
 			log.SetLevel(log.DebugLevel)
+			keyring.Debug = true
 		}
 	},
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -175,12 +175,17 @@ var addCmd = &cobra.Command{
 			log.Fatalf("failed to open keyring backend: %s", strings.ToLower(err.Error()))
 		}
 
-		_ = ring.Set(keyring.Item{
+		resp := ring.Set(keyring.Item{
 			Key:  fmt.Sprintf("%s-%s", profileName, authType),
 			Data: []byte(authValue),
 		})
 
-		fmt.Println("\nSuccess! Credentials have been set and are now ready for use!")
+		if resp == nil {
+			fmt.Println("\nSuccess! Credentials have been set and are now ready for use!")
+		} else {
+			// error of some sort
+			log.Fatal("Error adding credentials to keyring: ", resp)
+		}
 	},
 }
 

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -170,7 +170,10 @@ var addCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		ring, _ := keyring.Open(keyringDefaults)
+		ring, err := keyring.Open(keyringDefaults)
+		if err != nil {
+			log.Fatalf("failed to open keyring backend: %s", strings.ToLower(err.Error()))
+		}
 
 		_ = ring.Set(keyring.Item{
 			Key:  fmt.Sprintf("%s-%s", profileName, authType),

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -54,6 +54,7 @@ var execCmd = &cobra.Command{
 	PreRun: func(cmd *cobra.Command, args []string) {
 		if verbose {
 			log.SetLevel(log.DebugLevel)
+			keyring.Debug = true
 		}
 	},
 	Run: func(cmd *cobra.Command, args []string) {

--- a/script/build
+++ b/script/build
@@ -15,7 +15,7 @@ if [ -d build ]; then
 fi
 mkdir -p build
 
-platforms=("windows/amd64" "linux/amd64" "darwin/amd64")
+platforms=("windows/amd64" "linux/amd64" "darwin/amd64" "darwin/arm64")
 
 echo "==> Build started for v${version}"
 
@@ -35,9 +35,9 @@ do
   GCFLAGS="-gcflags=all=-trimpath=$GOPATH -asmflags=all=-trimpath=$GOPATH"
 
   if [ $GOOS = "windows" ]; then
-    env GOOS=$GOOS GOARCH=$GOARCH go build $GCFLAGS -o "build/${GOOS}/cf-vault.exe" -ldflags "-X github.com/jacobbednarz/cf-vault/cmd.Rev=${version_with_sha}" .
+    env GOOS=$GOOS GOARCH=$GOARCH go build $GCFLAGS -o "build/${GOOS}/${GOARCH}/cf-vault.exe" -ldflags "-X github.com/jacobbednarz/cf-vault/cmd.Rev=${version_with_sha}" .
   else
-    env GOOS=$GOOS GOARCH=$GOARCH go build $GCFLAGS -o "build/${GOOS}/cf-vault" -ldflags "-X github.com/jacobbednarz/cf-vault/cmd.Rev=${version_with_sha}" .
+    env GOOS=$GOOS GOARCH=$GOARCH go build $GCFLAGS -o "build/${GOOS}/${GOARCH}/cf-vault" -ldflags "-X github.com/jacobbednarz/cf-vault/cmd.Rev=${version_with_sha}" .
   fi
   if [ $? -ne 0 ]; then
     echo "Building the binary has failed!"
@@ -48,9 +48,9 @@ do
 
   printf "==> Tarballing %s\t%s\n" "$platform" "build/${output_name}.tar.gz" | expand -t 30
   if [ $GOOS = "windows" ]; then
-    tar -czf "build/${output_name}.tar.gz" -C "build/$GOOS" "cf-vault.exe"
+    tar -czf "build/${output_name}.tar.gz" -C "build/$GOOS/$GOARCH" "cf-vault.exe"
   else
-    tar -czf "build/${output_name}.tar.gz" -C "build/$GOOS" "cf-vault"
+    tar -czf "build/${output_name}.tar.gz" -C "build/$GOOS/$GOARCH" "cf-vault"
   fi
 
   if [ $? -ne 0 ]; then
@@ -59,7 +59,7 @@ do
   fi
 
   echo "==> Adding file checksums to build/checksums.txt"
-  shasum -a 256 build/$GOOS/* >> "build/checksums.txt"
+  shasum -a 256 build/$GOOS/$GOARCH/* >> "build/checksums.txt"
 done
 
 shasum -a 256 build/*.tar.gz >> "build/checksums.txt"


### PR DESCRIPTION
To help track down some of the Keyring issues we're seeing, here are a few improvements:

- Enable debug mode in Keyring when `verbose` is enabled
- In `add`, catch an error opening the keyring (same as in `exec`)
- Also in `add`, sorta catch an error when creating creds (see the commit comment in 988642d4985c95dd9e0d40839627a0df5c33bf80)
- Add `darwin/arm64` as a build target
- Add `$GOARCH` to the paths in the build script (otherwise the two `darwin` builds will step on each other)


